### PR TITLE
[Windows Fix] clearing the Temp Directory after Tests

### DIFF
--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -69,6 +69,9 @@ class RunCommand extends Command
             $returnCode = 1;
         }
 
+        $output->writeln('<run>Changing directory back to <run-bold>' . $this->projectRootPath . '</run-bold></run>');
+        chdir($this->projectRootPath);
+
         $output->writeln('<run>Cleaning up temporary directory <run-bold>' . $buildDirectory . '</run-bold></run>');
         $filesystem->remove($buildDirectory);
 


### PR DESCRIPTION
The **Windows Test Runner** ran into an Error caused while removing the temporary directory.
The Issue was caused due to php active directory (`chdir`) being in that particular directory.

Now the Test Runner will change the active directory to the project directory before trying to delete the Temporary Directory.